### PR TITLE
Fix path to ecosystem directory

### DIFF
--- a/alias
+++ b/alias
@@ -25,7 +25,7 @@ alias ledconv="${LEDGER_ECOSYSTEM_DIR}/convert.py"
 # When the latter are named consistently (ex:"apr2044_bank1.csv,
 # may2044_bank1.csv") one can use simple aliases to always convert the latest
 # CSV files. (Assuming monthly updates in this case.)
-THIS_AMN=$(date +'%b' | tr '[:upper:]' '[:lower:]') # Abreviated Month Name, ex: "apr"
+THIS_AMN=$(date +'%b' | tr '[:upper:]' '[:lower:]') # Abreviated Month Name, e.g. "apr"
 LAST_AMN=$(date +'%b' -d 'last month' | tr '[:upper:]' '[:lower:]') # "apr"
 THIS_YEAR=$(date +'%Y') # "2044"
 LAST_YEAR=$(date +'%Y' -d 'last year') # "2044"

--- a/alias
+++ b/alias
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LEDGER_ECOSYSTEM_DIR=$(dirname "$0") # needed for later
+LEDGER_ECOSYSTEM_DIR=$(dirname "$_") # needed for later
 
 # This is the main command to invoke Ledger.
 # --strict          : Warn if account, tag or commodity is unknown.


### PR DESCRIPTION
When the alias file is sourced "$0" is always set to the current directory "."
which leads e.g. ledreports to be set to the wrong path

```
alias ledreports=./reports.py
```

Use "$_" instead. See also http://unix.stackexchange.com/questions/4650/determining-path-to-sourced-shell-script
