### PR TITLE
Mac OS X compatibility

### DIFF
--- a/alias
+++ b/alias
@@ -27,11 +27,11 @@ alias ledconv="${LEDGER_ECOSYSTEM_DIR}/convert.py"
 # CSV files. (Assuming monthly updates in this case.)
 THIS_AMN=$(date +'%b' | tr '[:upper:]' '[:lower:]') # Abreviated Month Name, e.g. "apr"
 
-LINUX_DATE=$(date -d 'last year' 2>/dev/null)
-if [[ "$LINUX_DATE" == "" ]]; then
+GNU_DATE=$(date -d 'last year' 2>/dev/null)
+if [[ "$GNU_DATE" == "" ]]; then
   LAST_AMN=$(date -v-1m +'%b' | tr '[:upper:]' '[:lower:]') # "apr"
   LAST_YEAR=$(date -v-1y +'%Y') # "2044"
-  FST_DOM_6MONTHS_AGO=`date -v-6m +"%Y/%m/01" `
+  FST_DOM_6MONTHS_AGO=`date -v-6m +"%Y/%m/01"`
   FST_DOM_12MONTHS_AGO=`date -v-12m +"%Y/%m/01"`
 else
   LAST_AMN=$(date +'%b' -d 'last month' | tr '[:upper:]' '[:lower:]') # "apr"

--- a/alias
+++ b/alias
@@ -26,16 +26,27 @@ alias ledconv="${LEDGER_ECOSYSTEM_DIR}/convert.py"
 # may2044_bank1.csv") one can use simple aliases to always convert the latest
 # CSV files. (Assuming monthly updates in this case.)
 THIS_AMN=$(date +'%b' | tr '[:upper:]' '[:lower:]') # Abreviated Month Name, e.g. "apr"
-LAST_AMN=$(date +'%b' -d 'last month' | tr '[:upper:]' '[:lower:]') # "apr"
+
+LINUX_DATE=$(date -d 'last year' 2>/dev/null)
+if [[ "$LINUX_DATE" == "" ]]; then
+  LAST_AMN=$(date -v-1m +'%b' | tr '[:upper:]' '[:lower:]') # "apr"
+  LAST_YEAR=$(date -v-1y +'%Y') # "2044"
+  FST_DOM_6MONTHS_AGO=`date -v-6m +"%Y/%m/01" `
+  FST_DOM_12MONTHS_AGO=`date -v-12m +"%Y/%m/01"`
+else
+  LAST_AMN=$(date +'%b' -d 'last month' | tr '[:upper:]' '[:lower:]') # "apr"
+  LAST_YEAR=$(date +'%Y' -d 'last year') # "2044"
+  FST_DOM_6MONTHS_AGO=`date +"%Y/%m/01" -d "6 months ago"`
+  FST_DOM_12MONTHS_AGO=`date +"%Y/%m/01" -d "12 months ago"`
+fi
+
+
 THIS_YEAR=$(date +'%Y') # "2044"
-LAST_YEAR=$(date +'%Y' -d 'last year') # "2044"
 LAST_AMN_AND_YEAR="${LAST_AMN}${THIS_YEAR}" # "apr2044"
 if [[ "$LAST_AMN" == "dec" ]]; then
     LAST_AMN_AND_YEAR="${LAST_AMN}${LAST_YEAR}"
 fi
 # First Day Of Month x Months Ago (may be used for specific Ledger reports)
-FST_DOM_6MONTHS_AGO=`date +"%Y/%m/01" -d "6 months ago"`
-FST_DOM_12MONTHS_AGO=`date +"%Y/%m/01" -d "12 months ago"`
 
 function ledxact () {
     FILE=misc.tmp.txt

--- a/reports.py
+++ b/reports.py
@@ -14,8 +14,8 @@ import subprocess
 REPORT_FILE = 'reports.txt'
 TEMP_SCRIPT_FILE = '/tmp/.ledgerscript.sh'
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-COLOR_BLUE = '\\e[36m'
-COLOR_RESET = '\\e[0m'
+COLOR_BLUE = '\\033[36m'
+COLOR_RESET = '\\033[0m'
 CMD_EXPL_COLOR = COLOR_BLUE
 
 


### PR DESCRIPTION
Hello!
I try to start your GSWL scripts on Mac OS X (el capitan) and found that
1) BSD date command slightly differ from linux
2) By default mac have old bash and \e modifier does not work (i think \033 is more portable way)

Feel free to drop or merge this request.

BTW thank you for good writing, i like to read it.