### PR TITLE
Add possibility to use the € sign as a currency

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -125,7 +125,7 @@ def main(argv=None):
         cmd += ' --generated'  # pin automated transactions
         cmd += ' {}'.format(acfg['ledger_args'])
         cmd += ' | sed -e "s/\(^\s\+.*\s\+\)\([-0-9\.]\+\)$/\\1{}\\2/g"'.\
-            format(acfg['currency'])
+            format(acfg['currency'].encode('utf8'))
         try:
             cmd += ' | sed -e "s/Expenses:Unknown/{}/g"'.\
                 format(acfg['expenses_unknown'])


### PR DESCRIPTION
I get a codec error when I try to use the '€' sign as a commodity in an bank account.